### PR TITLE
Adding Custom Diagnostics Events by implementing DiagnosticSource

### DIFF
--- a/projects/RabbitMQ.Client/RabbitMQ.Client.csproj
+++ b/projects/RabbitMQ.Client/RabbitMQ.Client.csproj
@@ -61,6 +61,7 @@
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.4.0" PrivateAssets="All" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Threading.Channels" Version="5.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" />

--- a/projects/RabbitMQ.Client/RabbitMQ.Client.csproj
+++ b/projects/RabbitMQ.Client/RabbitMQ.Client.csproj
@@ -29,6 +29,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <ReleaseVersion>8.0</ReleaseVersion>
+    <VersionPrefix>6.1.0</VersionPrefix>
+    <VersionSuffix>sto</VersionSuffix>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(CONCOURSE_CI_BUILD)' == 'true'">
@@ -60,7 +62,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="MinVer" Version="2.4.0" PrivateAssets="All" />
+    <!--PackageReference Include="MinVer" Version="2.4.0" PrivateAssets="All" /--> <!-- Commented this to disable prerelease logic -->
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Threading.Channels" Version="5.0.0" />

--- a/projects/RabbitMQ.Client/client/diagnostics/DiagnosticAPMConstants.cs
+++ b/projects/RabbitMQ.Client/client/diagnostics/DiagnosticAPMConstants.cs
@@ -1,0 +1,25 @@
+﻿/*
+ *  1.0.0               20210315            shirhan.apache@gmail.com                Certain constants that are used to define events
+ *                                                                                  to be identified by the tracing instrumentation (in Elastic APM)
+ *                                                                                  Diagnostic source is implemented in RabbitMq client classes.
+ */
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RabbitMQ.Client.Diagnostics
+{
+    public enum DiagnosticAPMConstants
+    {
+        EXCEPTION = 0,
+        CREATE_CONNECTION_START = 11,
+        CREATE_CONNECTION_END = 12,
+        BASIC_PUBLISH_START = 13,
+        BASIC_PUBLISH_END = 14
+    }
+
+    public static class DiagnosticConstants
+    {
+        public static string DIAGNOSTIC_SOURCE_NAME = "RabbitMQ.Client.DiagnosticListener";
+    }
+}

--- a/projects/RabbitMQ.Client/client/diagnostics/DiagnosticAPMConstants.cs
+++ b/projects/RabbitMQ.Client/client/diagnostics/DiagnosticAPMConstants.cs
@@ -15,7 +15,9 @@ namespace RabbitMQ.Client.Diagnostics
         CREATE_CONNECTION_START = 11,
         CREATE_CONNECTION_END = 12,
         BASIC_PUBLISH_START = 13,
-        BASIC_PUBLISH_END = 14
+        BASIC_PUBLISH_END = 14,
+        BASIC_CONSUME_START = 15,
+        BASIC_CONSUME_END = 16
     }
 
     public static class DiagnosticConstants

--- a/projects/RabbitMQ.Client/client/diagnostics/DiagnosticAPMPayload.cs
+++ b/projects/RabbitMQ.Client/client/diagnostics/DiagnosticAPMPayload.cs
@@ -1,0 +1,19 @@
+﻿/*
+ *  1.0.0               20210315            shirhan.apache@gmail.com                Payload that is used to send information to
+ *                                                                                  the listener.
+ */
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RabbitMQ.Client.Diagnostics
+{
+    public class DiagnosticAPMPayload
+    {
+        public string Action { get; set; }
+        public string ActionType { get; set; }
+        public Guid? CorrelationId { get; set; }
+        public long TimeElapsed { get; set; }
+        public string Details { get; set; }
+    }
+}

--- a/projects/RabbitMQ.Client/client/impl/ModelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ModelBase.cs
@@ -29,14 +29,17 @@
 //  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
+//1.0.1				20210308				shirhan.apache@gmail.com						Adding DiagnosticSource to .Net Client
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using RabbitMQ.Client.ConsumerDispatching;
+using RabbitMQ.Client.Diagnostics;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Exceptions;
 using RabbitMQ.Client.Framing.Impl;
@@ -46,6 +49,8 @@ namespace RabbitMQ.Client.Impl
 {
     internal abstract class ModelBase : IModel, IRecoverable
     {
+        private static readonly DiagnosticSource ds = new DiagnosticListener(DiagnosticConstants.DIAGNOSTIC_SOURCE_NAME);   //1.0.1
+
         ///<summary>Only used to kick-start a connection open
         ///sequence. See <see cref="Connection.Open"/> </summary>
         internal BlockingCell<ConnectionStartDetails> m_connectionStartCell;
@@ -864,6 +869,18 @@ namespace RabbitMQ.Client.Impl
 
         public void BasicPublish(string exchange, string routingKey, bool mandatory, IBasicProperties basicProperties, ReadOnlyMemory<byte> body)
         {
+            //1.0.1
+            var sw = new Stopwatch();
+            sw.Start();
+            var payload = new DiagnosticAPMPayload()
+            {
+                Action = $"{typeof(ModelBase).FullName}.BasicPublish()",
+                ActionType = DiagnosticAPMConstants.BASIC_PUBLISH_START.ToString(),
+                CorrelationId = Guid.NewGuid()
+            };
+            ds.Write($"{typeof(ModelBase).FullName}.BasicPublish().Start", payload);
+            //1.0.1
+
             if (routingKey is null)
             {
                 throw new ArgumentNullException(nameof(routingKey));
@@ -882,6 +899,13 @@ namespace RabbitMQ.Client.Impl
                 mandatory,
                 basicProperties ?? _emptyBasicProperties,
                 body);
+
+            //1.0.1
+            sw.Stop();
+            payload.ActionType = DiagnosticAPMConstants.BASIC_PUBLISH_END.ToString();
+            payload.TimeElapsed = sw.ElapsedMilliseconds;
+            ds.Write($"{typeof(ModelBase).FullName}.BasicPublish().End", payload);
+            //1.0.1
         }
 
         public void BasicPublish(CachedString exchange, CachedString routingKey, bool mandatory, IBasicProperties basicProperties, ReadOnlyMemory<byte> body)

--- a/projects/RabbitMQ.Client/client/impl/ModelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ModelBase.cs
@@ -815,6 +815,18 @@ namespace RabbitMQ.Client.Impl
 
         public string BasicConsume(string queue, bool autoAck, string consumerTag, bool noLocal, bool exclusive, IDictionary<string, object> arguments, IBasicConsumer consumer)
         {
+            //1.0.1
+            var sw = new Stopwatch();
+            sw.Start();
+            var payload = new DiagnosticAPMPayload()
+            {
+                Action = $"{typeof(ModelBase).FullName}.BasicConsume()",
+                ActionType = DiagnosticAPMConstants.BASIC_CONSUME_START.ToString(),
+                CorrelationId = Guid.NewGuid()
+            };
+            ds.Write($"{typeof(ModelBase).FullName}.BasicConsume().Start", payload);
+            //1.0.1
+
             // TODO: Replace with flag
             if (ConsumerDispatcher is AsyncConsumerDispatcher)
             {
@@ -837,6 +849,13 @@ namespace RabbitMQ.Client.Impl
                 k.GetReply(ContinuationTimeout);
             }
             string actualConsumerTag = k.m_consumerTag;
+
+            //1.0.1
+            sw.Stop();
+            payload.ActionType = DiagnosticAPMConstants.BASIC_CONSUME_END.ToString();
+            payload.TimeElapsed = sw.ElapsedMilliseconds;
+            ds.Write($"{typeof(ModelBase).FullName}.BasicConsume().End", payload);
+            //1.0.1
 
             return actualConsumerTag;
         }


### PR DESCRIPTION
## Adding Custom Diagnostics Events by implementing DiagnosticSource
Adding DiagnosticSource to capture events when message publishing and consuming occurs. Initially planned to be used with Elastic APM (with Elasticsearch and Kibana)

## Types of Changes
Adds DiagnosticSource to ModelBase.cs and ConnectionFactory.cs
Adds additional classes for DTO and Enums in the _RabbitMQ.Client/client/diagnostics_ directory

What types of changes does your code introduce to this project?
- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [ ] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments
Had to resort to this in order to generalize the trace data instead of implementing trace code within the business logic.
Elastic APM agent would also be modified in parallel to be used with this version of RabbitMQ .Net Client.
